### PR TITLE
Fla 807 refactor username generator to generate guid

### DIFF
--- a/src/main/java/no/fintlabs/operator/NameFactory.java
+++ b/src/main/java/no/fintlabs/operator/NameFactory.java
@@ -6,29 +6,24 @@ import java.util.UUID;
 
 public class NameFactory {
 
+    public static String legacyNameFromMetadata(HasMetadata metadata) {
+        return String.format("%s_%s_%s",
+                metadata.getMetadata().getLabels().get("fintlabs.no/org-id").replace(".", "-"),
+                metadata.getMetadata().getLabels().get("fintlabs.no/team"),
+                metadata.getMetadata().getName()
+        );
+    }
+
+    public static String guidNameFromMetadata() {
+        return UUID.randomUUID().toString();
+    }
+
     public static String nameFromMetadata(HasMetadata metadata) {
-
-        String orgId = metadata.getMetadata().getLabels().get("fintlabs.no/org-id").replace(".", "-");
-        String team = metadata.getMetadata().getLabels().get("fintlabs.no/team");
-        String name = metadata.getMetadata().getName();
-        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
-
-        int maxCombinedPrefix = 64 - 19;
-        int totalPrefixLength = orgId.length() + team.length() + name.length();
-        if (totalPrefixLength > maxCombinedPrefix) {
-            double orgRatio = (double) orgId.length() / totalPrefixLength;
-            double teamRatio = (double) team.length() / totalPrefixLength;
-            double nameRatio = (double) name.length() / totalPrefixLength;
-
-            int maxOrgLength = (int) Math.floor(maxCombinedPrefix * orgRatio);
-            int maxTeamLength = (int) Math.floor(maxCombinedPrefix * teamRatio);
-            int maxNameLength = maxCombinedPrefix - maxOrgLength - maxTeamLength;
-
-            orgId = orgId.substring(0, Math.min(orgId.length(), maxOrgLength));
-            team = team.substring(0, Math.min(team.length(), maxTeamLength));
-            name = name.substring(0, Math.min(name.length(), maxNameLength));
+        String useGuid = metadata.getMetadata().getLabels().get("fintlabs.no/use-guid");
+        if ("true".equalsIgnoreCase(useGuid)) {
+            return guidNameFromMetadata();
+        } else {
+            return legacyNameFromMetadata(metadata);
         }
-
-        return String.format("%s-%s-%s-%s", orgId, team, name, uuid);
     }
 }

--- a/src/main/java/no/fintlabs/operator/NameFactory.java
+++ b/src/main/java/no/fintlabs/operator/NameFactory.java
@@ -2,13 +2,33 @@ package no.fintlabs.operator;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
+import java.util.UUID;
+
 public class NameFactory {
 
     public static String nameFromMetadata(HasMetadata metadata) {
-        return String.format("%s_%s_%s",
-                metadata.getMetadata().getLabels().get("fintlabs.no/org-id").replace(".", "-"),
-                metadata.getMetadata().getLabels().get("fintlabs.no/team"),
-                metadata.getMetadata().getName()
-        );
+
+        String orgId = metadata.getMetadata().getLabels().get("fintlabs.no/org-id").replace(".", "-");
+        String team = metadata.getMetadata().getLabels().get("fintlabs.no/team");
+        String name = metadata.getMetadata().getName();
+        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+
+        int maxCombinedPrefix = 64 - 19;
+        int totalPrefixLength = orgId.length() + team.length() + name.length();
+        if (totalPrefixLength > maxCombinedPrefix) {
+            double orgRatio = (double) orgId.length() / totalPrefixLength;
+            double teamRatio = (double) team.length() / totalPrefixLength;
+            double nameRatio = (double) name.length() / totalPrefixLength;
+
+            int maxOrgLength = (int) Math.floor(maxCombinedPrefix * orgRatio);
+            int maxTeamLength = (int) Math.floor(maxCombinedPrefix * teamRatio);
+            int maxNameLength = maxCombinedPrefix - maxOrgLength - maxTeamLength;
+
+            orgId = orgId.substring(0, Math.min(orgId.length(), maxOrgLength));
+            team = team.substring(0, Math.min(team.length(), maxTeamLength));
+            name = name.substring(0, Math.min(name.length(), maxNameLength));
+        }
+
+        return String.format("%s-%s-%s-%s", orgId, team, name, uuid);
     }
 }

--- a/src/test/groovy/no/fintlabs/operator/NameFactorySpec.groovy
+++ b/src/test/groovy/no/fintlabs/operator/NameFactorySpec.groovy
@@ -4,10 +4,10 @@ import spock.lang.Specification
 
 class NameFactorySpec extends Specification {
 
-    def "Name should contain orgId and team"() {
+    def "Generated name should include orgId, team and UUID"() {
         given:
         def crd = new KafkaUserAndAclCrd()
-        crd.getMetadata().getLabels().put("fintlabs.no/team", "flais")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "testteam")
         crd.getMetadata().getLabels().put("fintlabs.no/org-id", "flais.io")
         crd.getMetadata().setName("fint-data-service")
 
@@ -15,6 +15,36 @@ class NameFactorySpec extends Specification {
         def name = NameFactory.nameFromMetadata(crd)
 
         then:
-        name == "flais-io_flais_fint-data-service"
+        def parts = name.split("-")
+        parts.length >= 4
+
+        and: "UUID Should me last and 16 characters"
+        parts[-1] ==~ /^[a-f0-9]{16}$/
+
+        and: "Final string should be max 64 characters"
+        name.length() <= 64
+
+        and: "OrgID, team, and name should be included"
+        name.contains("test")
+        name.contains("flais")
+        name.contains("fint")
+    }
+
+    def "Should handle long orgId, team and name correctly"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "very-long-team-name-that-blows-all-borders")
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "insanely.long.organisation.identifier.that.exceeds.all.limits")
+        crd.getMetadata().setName("well-ok-we-know-this-name-is-too-long-now-right")
+
+        when:
+        def name = NameFactory.nameFromMetadata(crd)
+
+        then:
+        name.length() <= 64
+
+        and: def uuid = name.split("-")[-1]
+        uuid.length() == 16
+        uuid ==~ /^[a-f0-9]{16}$/
     }
 }

--- a/src/test/groovy/no/fintlabs/operator/NameFactorySpec.groovy
+++ b/src/test/groovy/no/fintlabs/operator/NameFactorySpec.groovy
@@ -4,47 +4,53 @@ import spock.lang.Specification
 
 class NameFactorySpec extends Specification {
 
-    def "Generated name should include orgId, team and UUID"() {
+    def "Legacy should include orgId, team and name"() {
         given:
         def crd = new KafkaUserAndAclCrd()
-        crd.getMetadata().getLabels().put("fintlabs.no/team", "testteam")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test-team")
         crd.getMetadata().getLabels().put("fintlabs.no/org-id", "flais.io")
+        crd.getMetadata().setName("fint-data-service")
+
+        when:
+        def name = NameFactory.legacyNameFromMetadata(crd)
+
+        then:
+        name.equals("flais-io_test-team_fint-data-service")
+    }
+
+    def "guidNameFromMetadata should return valid UUID format"() {
+        when:
+        def guid = NameFactory.guidNameFromMetadata()
+
+        then:
+        guid.matches(/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/)
+        guid.length() <= 64
+    }
+
+    def "nameFromMetadata should return GUID name is use-guid is set to true"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/use-guid", "true")
+
+        when:
+        def name = NameFactory.nameFromMetadata(crd)
+
+        then:
+        name.matches(/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/)
+    }
+
+    def "nameFromMetadata should return legacy name if use-guid is not true"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test-team")
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "flais.io")
+        crd.getMetadata().getLabels().put("fintlabs.no/use-guid", "false")
         crd.getMetadata().setName("fint-data-service")
 
         when:
         def name = NameFactory.nameFromMetadata(crd)
 
         then:
-        def parts = name.split("-")
-        parts.length >= 4
-
-        and: "UUID Should me last and 16 characters"
-        parts[-1] ==~ /^[a-f0-9]{16}$/
-
-        and: "Final string should be max 64 characters"
-        name.length() <= 64
-
-        and: "OrgID, team, and name should be included"
-        name.contains("test")
-        name.contains("flais")
-        name.contains("fint")
-    }
-
-    def "Should handle long orgId, team and name correctly"() {
-        given:
-        def crd = new KafkaUserAndAclCrd()
-        crd.getMetadata().getLabels().put("fintlabs.no/team", "very-long-team-name-that-blows-all-borders")
-        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "insanely.long.organisation.identifier.that.exceeds.all.limits")
-        crd.getMetadata().setName("well-ok-we-know-this-name-is-too-long-now-right")
-
-        when:
-        def name = NameFactory.nameFromMetadata(crd)
-
-        then:
-        name.length() <= 64
-
-        and: def uuid = name.split("-")[-1]
-        uuid.length() == 16
-        uuid ==~ /^[a-f0-9]{16}$/
+        name.equals("flais-io_test-team_fint-data-service")
     }
 }


### PR DESCRIPTION
Refactored to include randomized string at the end of full name. If name is over 64 chars it will truncate orgId, team and name.

Wrote tests to prove the concept.