### PR TITLE
FLA-1647-refactor username-generation

### DIFF
--- a/.github/workflows/build-deployment.yaml
+++ b/.github/workflows/build-deployment.yaml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
 
   deploy-alpha:
-    if: github.event.name == 'workflow_dispatch' && inputs.environment == 'alpha'
+    if: github.event_name == 'workflow_dispatch' && inputs.environment == 'alpha'
     uses: ./.github/workflows/.cluster-deploy.yaml
     needs: build-publish
     secrets: inherit

--- a/examples/sample.yaml
+++ b/examples/sample.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/version: latest
     app.kubernetes.io/component: sample
     app.kubernetes.io/part-of: sample-test
+    kafka.fintlabs.no/name-version: v2
     fintlabs.no/team: sample-test
     fintlabs.no/org-id: fintlabs.no
 spec:

--- a/src/main/java/no/fintlabs/aiven/AivenService.java
+++ b/src/main/java/no/fintlabs/aiven/AivenService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.core.publisher.Mono;
 
 import javax.annotation.PostConstruct;
 import java.util.*;
@@ -36,22 +35,35 @@ public class AivenService {
 
     public Optional<KafkaUserAndAcl> getUserAndAcl(String username) {
         try {
-            // TODO: 22/11/2022 Create separate models for GET
-            CreateKafkaUserResponse createKafkaUserResponse = webClient.get()
-                    .uri("/project/{project_name}/service/{service_name}/user/{username}", aivenProperties.getProject(), aivenProperties.getService(), username)
+
+            GetKafkaUserResponse getKafkaUserResponse = webClient.get()
+                    .uri(
+                            "/project/{project_name}/service/{service_name}/user/{username}",
+                            aivenProperties.getProject(),
+                            aivenProperties.getService(),
+                            username
+                    )
                     .retrieve()
-                    .bodyToMono(CreateKafkaUserResponse.class)
+                    .bodyToMono(GetKafkaUserResponse.class)
                     .block();
 
-            // TODO: 22/11/2022 Create separate models for GET
-            CreateKafkaAclEntryResponse aclEntryResponse = webClient.get()
-                    .uri("/project/{project_name}/service/{service_name}/acl", aivenProperties.getProject(), aivenProperties.getService())
+            GetKafkaAclEntryResponse aclEntryResponse = webClient.get()
+                    .uri(
+                            "/project/{project_name}/service/{service_name}/acl",
+                            aivenProperties.getProject(),
+                            aivenProperties.getService()
+                    )
                     .retrieve()
-                    .bodyToMono(CreateKafkaAclEntryResponse.class)
+                    .bodyToMono(GetKafkaAclEntryResponse.class)
                     .block();
 
-            return Optional.ofNullable(KafkaUserAndAcl.fromUserAndAclResponse(createKafkaUserResponse, aclEntryResponse));
+            if (getKafkaUserResponse == null || getKafkaUserResponse.getUser() == null || aclEntryResponse == null) {
+                return Optional.empty();
+            }
 
+            return Optional.of(
+                    KafkaUserAndAcl.fromUserAndAclResponse(getKafkaUserResponse, aclEntryResponse)
+            );
 
         } catch (WebClientResponseException e) {
             if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
@@ -64,25 +76,48 @@ public class AivenService {
         }
     }
 
+    public AivenServiceUser ensureUserForService(String username) {
+        return getUserAndAcl(username)
+                .map(KafkaUserAndAcl::getUser)
+                .orElseGet(() -> createUserForService(username));
+    }
+
     public AivenServiceUser createUserForService(String username) {
         log.debug("Creating user {} for service {}", username, aivenProperties.getService());
+        try {
 
-        CreateKafkaUserResponse createKafkaUserResponse = Optional.ofNullable(webClient.post()
-                        .uri("/project/{project_name}/service/{service_name}/user", aivenProperties.getProject(), aivenProperties.getService())
-                        .body(BodyInserters.fromValue(new CreateKafkaUserRequest(username)))
-                        .retrieve()
-                        .onStatus(httpStatus -> httpStatus.value() == 409, clientResponse -> {
-                            log.debug("User already exists");
-                            return Mono.empty();
+            CreateKafkaUserResponse createKafkaUserResponse = Optional.ofNullable(webClient.post()
+                            .uri(
+                                    "/project/{project_name}/service/{service_name}/user",
+                                    aivenProperties.getProject(),
+                                    aivenProperties.getService()
+                            )
+                            .body(BodyInserters.fromValue(new CreateKafkaUserRequest(username)))
+                            .retrieve()
+                            .bodyToMono(CreateKafkaUserResponse.class)
+                            .block())
+                    .orElseThrow();
 
-                        })
-                        .bodyToMono(CreateKafkaUserResponse.class)
-                        .block())
-                .orElseThrow();
+            log.debug(
+                    "Created Aiven Kafka service user with message: {}",
+                    Objects.requireNonNull(createKafkaUserResponse).getMessage()
+            );
 
-        log.debug("Created Aiven Kafka service user with message: {}", Objects.requireNonNull(createKafkaUserResponse).getMessage());
+            return createKafkaUserResponse.getUser();
 
-        return createKafkaUserResponse.getUser();
+        } catch (WebClientResponseException exception) {
+            if (exception.getStatusCode() == HttpStatus.CONFLICT) {
+                log.debug("User {} already exists. Fetching user...", username);
+
+                return getUserAndAcl(username)
+                        .map(KafkaUserAndAcl::getUser)
+                        .orElseThrow(() -> new IllegalStateException(
+                                "User already exists, but could not be fetched: " + username
+                        ));
+            }
+
+            throw exception;
+        }
     }
 
     public void deleteUserForService(String username) {
@@ -96,29 +131,72 @@ public class AivenService {
                 .block();
     }
 
+    public KafkaAclEntry ensureAclEntryForTopic(KafkaAclEntry desiredAclEntry) {
+        return getUserAndAcl(desiredAclEntry.getUsername())
+                .flatMap(userAndAcl -> userAndAcl.getAclEntries()
+                        .stream()
+                        .filter(existingAclEntry ->
+                                Objects.equals(existingAclEntry.getTopic(), desiredAclEntry.getTopic())
+                                        && Objects.equals(existingAclEntry.getPermission(), desiredAclEntry.getPermission())
+                        )
+                        .findFirst()
+                )
+                .orElseGet(() -> createAclEntryForTopic(desiredAclEntry));
+    }
+
     public KafkaAclEntry createAclEntryForTopic(KafkaAclEntry aclEntry) {
         log.debug("Creating ACL entry for topic {} for user {} with permission {}", aclEntry.getTopic(), aclEntry.getUsername(), aclEntry.getPermission());
 
         validatePermission(aclEntry.getPermission());
 
-        return webClient
-                .post()
-                .uri("/project/{project_name}/service/{service_name}/acl", aivenProperties.getProject(), aivenProperties.getService())
-                .body(BodyInserters.fromValue(
-                        CreateKafkaAclEntryRequest
-                                .builder()
-                                .topic(aclEntry.getTopic())
-                                .permission(aclEntry.getPermission())
-                                .username(aclEntry.getUsername())
-                                .build()
-                ))
-                .retrieve()
-                .onStatus(httpStatus -> httpStatus.value() == 409, clientResponse -> {
-                    log.debug("Acl already exists");
-                    return Mono.empty();
+        try {
+            CreateKafkaAclEntryResponse response = webClient
+                    .post()
+                    .uri("/project/{project_name}/service/{service_name}/acl", aivenProperties.getProject(), aivenProperties.getService())
+                    .body(BodyInserters.fromValue(
+                            CreateKafkaAclEntryRequest
+                                    .builder()
+                                    .topic(aclEntry.getTopic())
+                                    .permission(aclEntry.getPermission())
+                                    .username(aclEntry.getUsername())
+                                    .build()
+                    ))
+                    .retrieve()
+                    .bodyToMono(CreateKafkaAclEntryResponse.class)
+                    .block();
 
-                }).bodyToMono(CreateKafkaAclEntryResponse.class)
-                .block().getAclByUsernameAndTopic(aclEntry.getUsername(), aclEntry.getTopic());
+            return Optional.ofNullable(Objects.requireNonNull(response)
+                            .getAclByUsernameAndTopic(aclEntry.getUsername(), aclEntry.getTopic()))
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Created ACL, but could not find it in response for user "
+                                    + aclEntry.getUsername()
+                                    + " and topic "
+                                    + aclEntry.getTopic()
+                    ));
+
+        } catch (WebClientResponseException exception) {
+            if (exception.getStatusCode() == HttpStatus.CONFLICT) {
+                log.debug("ACL already exists. Fetching existing ACL for user {} and topic {}", aclEntry.getUsername(), aclEntry.getTopic());
+
+                return getUserAndAcl(aclEntry.getUsername())
+                        .flatMap(userAndAcl -> userAndAcl.getAclEntries()
+                                .stream()
+                                .filter(existingAclEntry ->
+                                        Objects.equals(existingAclEntry.getTopic(), aclEntry.getTopic())
+                                                && Objects.equals(existingAclEntry.getPermission(), aclEntry.getPermission())
+                                )
+                                .findFirst()
+                        )
+                        .orElseThrow(() -> new IllegalStateException(
+                                "ACL already exists, but could not be fetched for user "
+                                        + aclEntry.getUsername()
+                                        + " and topic "
+                                        + aclEntry.getTopic()
+                        ));
+            }
+
+            throw exception;
+        }
     }
 
     public void deleteAclEntryForService(String aclId) {
@@ -137,7 +215,7 @@ public class AivenService {
         Collection<KafkaAclEntry> aclEntriesToAdd = CollectionUtils.removeAll(desired.getAclEntries(), actual.getAclEntries());
 
         aclEntriesToRemove.forEach(aclEntry -> deleteAclEntryForService(aclEntry.getId()));
-        aclEntriesToAdd.forEach(this::createAclEntryForTopic);
+        aclEntriesToAdd.forEach(this::ensureAclEntryForTopic);
         return getUserAndAcl(desired.getUser().getUsername()).orElseThrow();
     }
 

--- a/src/main/java/no/fintlabs/aiven/GetKafkaAclEntryResponse.java
+++ b/src/main/java/no/fintlabs/aiven/GetKafkaAclEntryResponse.java
@@ -1,0 +1,21 @@
+package no.fintlabs.aiven;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class GetKafkaAclEntryResponse implements Serializable {
+    @JsonProperty("acl")
+    private List<KafkaAclEntry> kafkaAclEntry = new ArrayList<>();
+
+    public KafkaAclEntry getAclByUsernameAndTopic(String username, String topic) {
+        return kafkaAclEntry.stream()
+                .filter(acl -> acl.getUsername().equals(username) && acl.getTopic().equals(topic))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/no/fintlabs/aiven/GetKafkaUserResponse.java
+++ b/src/main/java/no/fintlabs/aiven/GetKafkaUserResponse.java
@@ -1,0 +1,10 @@
+package no.fintlabs.aiven;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class GetKafkaUserResponse implements Serializable {
+    private AivenServiceUser user;
+}

--- a/src/main/java/no/fintlabs/operator/Constants.java
+++ b/src/main/java/no/fintlabs/operator/Constants.java
@@ -1,0 +1,12 @@
+package no.fintlabs.operator;
+
+public class Constants {
+    static final String ORG_ID_LABEL = "fintlabs.no/org-id";
+    static final String TEAM_LABEL = "fintlabs.no/team";
+    static final int ORG_NAME_LENGTH = 10;
+    static final int TEAM_NAME_LENGTH = 15;
+    static final int APP_NAME_LENGTH = 25;
+    static final String SHOULD_USE_NAME_V2 = "SHOULD_USE_NAME_V2";
+    static final String NAME_VERSION_ANNOTATION = "kafka.fintlabs.no/name-version";
+    static final String NAME_VERSION_V2 = "v2";
+}

--- a/src/main/java/no/fintlabs/operator/KafkaUserAclReconciler.java
+++ b/src/main/java/no/fintlabs/operator/KafkaUserAclReconciler.java
@@ -1,6 +1,7 @@
 package no.fintlabs.operator;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ContextInitializer;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
@@ -12,10 +13,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static no.fintlabs.operator.Constants.*;
+
 @Slf4j
 @Component
 @ControllerConfiguration
-public class KafkaUserAclReconciler extends FlaisReconiler<KafkaUserAndAclCrd, KafkaUserAndAclSpec> {
+public class KafkaUserAclReconciler extends FlaisReconiler<KafkaUserAndAclCrd, KafkaUserAndAclSpec> implements ContextInitializer<KafkaUserAndAclCrd> {
 
     public KafkaUserAclReconciler(
             FlaisWorkflow<KafkaUserAndAclCrd, KafkaUserAndAclSpec> workflow,
@@ -30,14 +33,19 @@ public class KafkaUserAclReconciler extends FlaisReconiler<KafkaUserAndAclCrd, K
             KafkaUserAndAclCrd resource,
             Context<KafkaUserAndAclCrd> context
     ) {
-        String username = NameFactory.userName(resource);
 
-        log.info(
-                "Using Kafka username {} for resource {}",
-                username,
-                resource.getMetadata().getName()
-        );
+        var useNameV2 = context.managedDependentResourceContext().get(SHOULD_USE_NAME_V2, Boolean.class).orElse(false);
+        if (useNameV2) {
+            resource.getMetadata().getAnnotations().put(NAME_VERSION_ANNOTATION, NAME_VERSION_V2);
+        }
 
         return super.reconcile(resource, context);
+    }
+
+    @Override
+    public void initContext(KafkaUserAndAclCrd primary, Context<KafkaUserAndAclCrd> context) {
+        if (primary.getStatus() == null || primary.getStatus().getObservedGeneration() == null || NameFactory.usesNameVersionV2(primary)) {
+            context.managedDependentResourceContext().put(SHOULD_USE_NAME_V2, true);
+        }
     }
 }

--- a/src/main/java/no/fintlabs/operator/KafkaUserAclReconciler.java
+++ b/src/main/java/no/fintlabs/operator/KafkaUserAclReconciler.java
@@ -1,6 +1,8 @@
 package no.fintlabs.operator;
 
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import lombok.extern.slf4j.Slf4j;
@@ -14,11 +16,28 @@ import java.util.List;
 @Component
 @ControllerConfiguration
 public class KafkaUserAclReconciler extends FlaisReconiler<KafkaUserAndAclCrd, KafkaUserAndAclSpec> {
-    public KafkaUserAclReconciler(FlaisWorkflow<KafkaUserAndAclCrd,
-            KafkaUserAndAclSpec> workflow,
-                                  List<? extends DependentResource<?, KafkaUserAndAclCrd>> eventSourceProviders,
 
-                                  List<? extends Deleter<KafkaUserAndAclCrd>> deleters) {
+    public KafkaUserAclReconciler(
+            FlaisWorkflow<KafkaUserAndAclCrd, KafkaUserAndAclSpec> workflow,
+            List<? extends DependentResource<?, KafkaUserAndAclCrd>> eventSourceProviders,
+            List<? extends Deleter<KafkaUserAndAclCrd>> deleters
+    ) {
         super(workflow, eventSourceProviders, deleters);
+    }
+
+    @Override
+    public UpdateControl<KafkaUserAndAclCrd> reconcile(
+            KafkaUserAndAclCrd resource,
+            Context<KafkaUserAndAclCrd> context
+    ) {
+        String username = NameFactory.userName(resource);
+
+        log.info(
+                "Using Kafka username {} for resource {}",
+                username,
+                resource.getMetadata().getName()
+        );
+
+        return super.reconcile(resource, context);
     }
 }

--- a/src/main/java/no/fintlabs/operator/KafkaUserAndAcl.java
+++ b/src/main/java/no/fintlabs/operator/KafkaUserAndAcl.java
@@ -1,13 +1,15 @@
 package no.fintlabs.operator;
 
 import lombok.*;
-import no.fintlabs.aiven.CreateKafkaAclEntryResponse;
-import no.fintlabs.aiven.CreateKafkaUserResponse;
-import no.fintlabs.aiven.KafkaAclEntry;
 import no.fintlabs.aiven.AivenServiceUser;
+import no.fintlabs.aiven.GetKafkaAclEntryResponse;
+import no.fintlabs.aiven.GetKafkaUserResponse;
+import no.fintlabs.aiven.KafkaAclEntry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Getter
@@ -20,14 +22,18 @@ public class KafkaUserAndAcl {
     private AivenServiceUser user;
     private List<KafkaAclEntry> aclEntries = new ArrayList<>();
 
-    public static KafkaUserAndAcl fromUserAndAclResponse(CreateKafkaUserResponse user, CreateKafkaAclEntryResponse acl) {
+    public static KafkaUserAndAcl fromUserAndAclResponse(GetKafkaUserResponse user, GetKafkaAclEntryResponse acl) {
+        String username = user.getUser().getUsername();
+
         return KafkaUserAndAcl.builder()
                 .user(user.getUser())
                 .aclEntries(
-                        acl
-                                .getKafkaAclEntry()
+                        Optional.ofNullable(acl.getKafkaAclEntry())
+                                .orElseGet(ArrayList::new)
                                 .stream()
-                                .filter(kafkaAclEntry -> kafkaAclEntry.getUsername().equals(user.getUser().getUsername()))
+                                .filter(kafkaAclEntry ->
+                                        Objects.equals(kafkaAclEntry.getUsername(), username)
+                                )
                                 .collect(Collectors.toList())
                 )
                 .build();

--- a/src/main/java/no/fintlabs/operator/KafkaUserAndAclDependentResource.java
+++ b/src/main/java/no/fintlabs/operator/KafkaUserAndAclDependentResource.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static no.fintlabs.operator.NameFactory.nameFromMetadata;
+import static no.fintlabs.operator.NameFactory.serviceUserName;
 
 @Slf4j
 @Component
@@ -40,14 +40,18 @@ public class KafkaUserAndAclDependentResource extends FlaisExternalDependentReso
     @Override
     protected KafkaUserAndAcl desired(KafkaUserAndAclCrd primary, Context<KafkaUserAndAclCrd> context) {
 
+        String orgName = primary.getMetadata().getLabels().get("fintlabs.no/org-id");
+        String teamName = primary.getMetadata().getLabels().get("fintlabs.no/team");
+        String appName = primary.getMetadata().getName();
+
         return KafkaUserAndAcl.builder()
-                .user(AivenServiceUser.fromUsername(nameFromMetadata(primary)))
+                .user(AivenServiceUser.fromUsername(serviceUserName(orgName, teamName, appName)))
                 .aclEntries(
                         primary
                                 .getSpec()
                                 .getAcls()
                                 .stream()
-                                .map(acl -> acl.toAclEntry(nameFromMetadata(primary)))
+                                .map(acl -> acl.toAclEntry(serviceUserName(orgName, teamName, appName)))
                                 .collect(Collectors.toList())
                 )
                 .build();
@@ -98,10 +102,14 @@ public class KafkaUserAndAclDependentResource extends FlaisExternalDependentReso
 
 
     @Override
-    public Set<KafkaUserAndAcl> fetchResources(KafkaUserAndAclCrd primaryResource) {
+    public Set<KafkaUserAndAcl> fetchResources(KafkaUserAndAclCrd primary) {
+
+        String orgName = primary.getMetadata().getLabels().get("fintlabs.no/org-id");
+        String teamName = primary.getMetadata().getLabels().get("fintlabs.no/team");
+        String appName = primary.getMetadata().getName();
 
         return aivenService
-                .getUserAndAcl(nameFromMetadata(primaryResource))
+                .getUserAndAcl(serviceUserName(orgName, teamName, appName))
                 .map(Collections::singleton)
                 .orElse(Collections.emptySet());
     }

--- a/src/main/java/no/fintlabs/operator/KafkaUserAndAclDependentResource.java
+++ b/src/main/java/no/fintlabs/operator/KafkaUserAndAclDependentResource.java
@@ -20,8 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static no.fintlabs.operator.NameFactory.serviceUserName;
-
 @Slf4j
 @Component
 public class KafkaUserAndAclDependentResource extends FlaisExternalDependentResource<KafkaUserAndAcl, KafkaUserAndAclCrd, KafkaUserAndAclSpec>
@@ -40,18 +38,17 @@ public class KafkaUserAndAclDependentResource extends FlaisExternalDependentReso
     @Override
     protected KafkaUserAndAcl desired(KafkaUserAndAclCrd primary, Context<KafkaUserAndAclCrd> context) {
 
-        String orgName = primary.getMetadata().getLabels().get("fintlabs.no/org-id");
-        String teamName = primary.getMetadata().getLabels().get("fintlabs.no/team");
-        String appName = primary.getMetadata().getName();
+        var useNameV2 = context.managedDependentResourceContext().get(Constants.SHOULD_USE_NAME_V2, Boolean.class).orElse(false);
+        var userName = NameFactory.userName(primary, useNameV2);
 
         return KafkaUserAndAcl.builder()
-                .user(AivenServiceUser.fromUsername(serviceUserName(orgName, teamName, appName)))
+                .user(AivenServiceUser.fromUsername(userName))
                 .aclEntries(
                         primary
                                 .getSpec()
                                 .getAcls()
                                 .stream()
-                                .map(acl -> acl.toAclEntry(serviceUserName(orgName, teamName, appName)))
+                                .map(acl -> acl.toAclEntry(userName))
                                 .collect(Collectors.toList())
                 )
                 .build();
@@ -80,14 +77,14 @@ public class KafkaUserAndAclDependentResource extends FlaisExternalDependentReso
     public KafkaUserAndAcl create(KafkaUserAndAcl desired, KafkaUserAndAclCrd primary, Context<KafkaUserAndAclCrd> context) {
         String serviceName = aivenProperties.getService();
 
-        AivenServiceUser aivenServiceUser = aivenService.createUserForService(desired.getUser().getUsername());
-        log.debug("Created user {} for service {}", desired.getUser().getUsername(), serviceName);
+        AivenServiceUser aivenServiceUser = aivenService.ensureUserForService(desired.getUser().getUsername());
+        log.debug("Ensured user {} for service {}", desired.getUser().getUsername(), serviceName);
 
         List<KafkaAclEntry> kafkaAclEntries = desired.getAclEntries()
                 .stream()
                 .map(kafkaAclEntry -> {
-                    KafkaAclEntry aclEntryForTopic = aivenService.createAclEntryForTopic(kafkaAclEntry);
-                    log.debug("Created ACL for user {} on topic {}", kafkaAclEntry.getUsername(), kafkaAclEntry.getTopic());
+                    KafkaAclEntry aclEntryForTopic = aivenService.ensureAclEntryForTopic(kafkaAclEntry);
+                    log.debug("Ensured ACL for user {} on topic {}", kafkaAclEntry.getUsername(), kafkaAclEntry.getTopic());
                     return aclEntryForTopic;
 
                 })
@@ -103,13 +100,10 @@ public class KafkaUserAndAclDependentResource extends FlaisExternalDependentReso
 
     @Override
     public Set<KafkaUserAndAcl> fetchResources(KafkaUserAndAclCrd primary) {
-
-        String orgName = primary.getMetadata().getLabels().get("fintlabs.no/org-id");
-        String teamName = primary.getMetadata().getLabels().get("fintlabs.no/team");
-        String appName = primary.getMetadata().getName();
+        String username = NameFactory.userName(primary, NameFactory.usesNameVersionV2(primary));
 
         return aivenService
-                .getUserAndAcl(serviceUserName(orgName, teamName, appName))
+                .getUserAndAcl(username)
                 .map(Collections::singleton)
                 .orElse(Collections.emptySet());
     }

--- a/src/main/java/no/fintlabs/operator/NameFactory.java
+++ b/src/main/java/no/fintlabs/operator/NameFactory.java
@@ -5,23 +5,15 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32;
 
+import static no.fintlabs.operator.Constants.*;
+
 public class NameFactory {
-    private static final int ORG_NAME_LENGTH = 10;
-    private static final int TEAM_NAME_LENGTH = 15;
-    private static final int APP_NAME_LENGTH = 25;
-
-    private static final String ORG_ID_LABEL = "fintlabs.no/org-id";
-    private static final String TEAM_LABEL = "fintlabs.no/team";
-
-    private static final String NAME_VERSION_ANNOTATION = "kafka.fintlabs.no/name-version";
-    private static final String NAME_VERSION_V2 = "v2";
-
-    public static String userName(HasMetadata metadata) {
-        if(usesNameVersionV2(metadata)){
+    public static String userName(HasMetadata metadata, boolean useV2) {
+        if (useV2) {
             return serviceUserName(
-              metadata.getMetadata().getLabels().get(ORG_ID_LABEL),
-              metadata.getMetadata().getLabels().get(TEAM_LABEL),
-              metadata.getMetadata().getName()
+                    metadata.getMetadata().getLabels().get(ORG_ID_LABEL),
+                    metadata.getMetadata().getLabels().get(TEAM_LABEL),
+                    metadata.getMetadata().getName()
             );
         }
 
@@ -51,7 +43,7 @@ public class NameFactory {
         );
     }
 
-    private static boolean usesNameVersionV2(HasMetadata metadata) {
+    public static boolean usesNameVersionV2(HasMetadata metadata) {
         var annotations = metadata.getMetadata().getAnnotations();
 
         return annotations != null

--- a/src/main/java/no/fintlabs/operator/NameFactory.java
+++ b/src/main/java/no/fintlabs/operator/NameFactory.java
@@ -2,13 +2,110 @@ package no.fintlabs.operator;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
-public class NameFactory {
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 
-    public static String nameFromMetadata(HasMetadata metadata) {
+public class NameFactory {
+    private static final int ORG_NAME_LENGTH = 10;
+    private static final int TEAM_NAME_LENGTH = 15;
+    private static final int APP_NAME_LENGTH = 25;
+
+    private static final String ORG_ID_LABEL = "fintlabs.no/org-id";
+    private static final String TEAM_LABEL = "fintlabs.no/team";
+
+    private static final String NAME_VERSION_ANNOTATION = "kafka.fintlabs.no/name-version";
+    private static final String NAME_VERSION_V2 = "v2";
+
+    public static String userName(HasMetadata metadata) {
+        if(usesNameVersionV2(metadata)){
+            return serviceUserName(
+              metadata.getMetadata().getLabels().get(ORG_ID_LABEL),
+              metadata.getMetadata().getLabels().get(TEAM_LABEL),
+              metadata.getMetadata().getName()
+            );
+        }
+
+        return legacyUserName(metadata);
+    }
+
+    public static String serviceUserName(
+            String orgName,
+            String teamName,
+            String appName
+    ) {
+        String hash = hashedName(teamName, appName, orgName);
+
+        return "%s_%s_%s_%s".formatted(
+                shortOrgName(orgName),
+                shortTeamName(teamName),
+                shortAppName(teamName, appName),
+                hash
+        );
+    }
+
+    public static String legacyUserName(HasMetadata metadata) {
         return String.format("%s_%s_%s",
-                metadata.getMetadata().getLabels().get("fintlabs.no/org-id").replace(".", "-"),
-                metadata.getMetadata().getLabels().get("fintlabs.no/team"),
+                metadata.getMetadata().getLabels().get(ORG_ID_LABEL).replace(".", "-"),
+                metadata.getMetadata().getLabels().get(TEAM_LABEL),
                 metadata.getMetadata().getName()
         );
+    }
+
+    private static boolean usesNameVersionV2(HasMetadata metadata) {
+        var annotations = metadata.getMetadata().getAnnotations();
+
+        return annotations != null
+                && NAME_VERSION_V2.equals(annotations.get(NAME_VERSION_ANNOTATION));
+    }
+
+    private static String hashedName(String teamName, String appName, String orgName) {
+        CRC32 crc32 = new CRC32();
+        String baseName = teamName + appName + orgName;
+        byte[] bytes = baseName.getBytes(StandardCharsets.UTF_8);
+
+        crc32.update(bytes, 0, bytes.length);
+
+        return "%08x".formatted(crc32.getValue());
+    }
+
+    private static String shortOrgName(String orgName) {
+        return shorten(orgName, null, "_no", ORG_NAME_LENGTH);
+    }
+
+    private static String shortTeamName(String teamName) {
+        return shorten(teamName, "team", null, TEAM_NAME_LENGTH);
+    }
+
+    private static String shortAppName(String teamName, String appName) {
+        return shorten(appName, teamName, null, APP_NAME_LENGTH);
+    }
+
+    private static String shorten(String input, String prefix, String suffix, int maxLen) {
+        input = input
+                .toLowerCase()
+                .replace(".", "_")
+                .replaceAll("[^a-z0-9_-]", "");
+
+        if (prefix != null && input.startsWith(prefix) && !input.equals(prefix)) {
+            input = input.substring(prefix.length());
+        }
+
+        if (suffix != null && input.endsWith(suffix) && !input.equals(suffix)) {
+            input = input.substring(0, input.length() - suffix.length());
+        }
+
+        while (!input.isEmpty() && input.charAt(0) == '-') {
+            input = input.substring(1);
+        }
+
+        if (input.length() > maxLen) {
+            input = input.substring(0, maxLen);
+        }
+
+        while (input.length() > 1 && input.charAt(input.length() - 1) == '-') {
+            input = input.substring(0, input.length() - 1);
+        }
+
+        return input;
     }
 }

--- a/src/test/groovy/no/fintlabs/aiven/AivenServiceTest.java
+++ b/src/test/groovy/no/fintlabs/aiven/AivenServiceTest.java
@@ -66,13 +66,36 @@ class AivenServiceTest {
 
     @Test
     void getUserAndAcl_ShouldReturnUserAndAcl_WhenUserExists() {
-        String userResponseJson = "{ \"username\": \"test_user\", \"...\": \"...\" }";
+        String userResponseJson = """
+        {
+            "user": {
+                "username": "test_user"
+            }
+        }
+        """;
         mockWebServer.enqueue(new MockResponse()
                 .setResponseCode(HttpStatus.OK.value())
                 .setBody(userResponseJson)
                 .addHeader("Content-Type", "application/json"));
 
-        String aclResponseJson = "{ \"entries\": [ { \"permission\": \"read\", \"username\": \"test_user\" } ] }";
+        String aclResponseJson = """
+                {
+                    "acl": [
+                        {
+                          "id": "acl-1",
+                          "permission": "read",
+                          "username": "test_user",
+                          "topic": "test-topic"
+                        },
+                        {
+                          "id": "acl-2",
+                          "permission": "write",
+                          "username": "other_user",
+                          "topic": "other-topic"
+                        }
+                    ]
+                }
+                """;
         mockWebServer.enqueue(new MockResponse()
                 .setResponseCode(HttpStatus.OK.value())
                 .setBody(aclResponseJson)
@@ -81,5 +104,74 @@ class AivenServiceTest {
         Optional<KafkaUserAndAcl> result = service.getUserAndAcl("test_user");
 
         assertTrue(result.isPresent(), "Expected to find KafkaUserAndAcl");
+        assertEquals("test_user", result.get().getUser().getUsername());
+        assertEquals(1, result.get().getAclEntries().size());
+        assertEquals("test_user", result.get().getAclEntries().get(0).getUsername());
+        assertEquals("test-topic", result.get().getAclEntries().get(0).getTopic());
+        assertEquals("read", result.get().getAclEntries().get(0).getPermission());
+    }
+
+    @Test
+    void ensureUserForService_ShouldReturnExistingUser_WhenUserExists() throws InterruptedException {
+        String userResponseJson = """
+            {
+              "user": {
+                "username": "test_user"
+              }
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(HttpStatus.OK.value())
+                .setBody(userResponseJson)
+                .addHeader("Content-Type", "application/json"));
+
+        String aclResponseJson = """
+            {
+              "acl": []
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(HttpStatus.OK.value())
+                .setBody(aclResponseJson)
+                .addHeader("Content-Type", "application/json"));
+
+        AivenServiceUser result = service.ensureUserForService("test_user");
+
+        assertEquals("test_user", result.getUsername());
+        assertEquals(2, mockWebServer.getRequestCount());
+
+        assertEquals("GET", mockWebServer.takeRequest().getMethod());
+        assertEquals("GET", mockWebServer.takeRequest().getMethod());
+    }
+
+    @Test
+    void ensureUserForService_ShouldCreateUser_WhenUserDoesNotExist() throws InterruptedException {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(HttpStatus.NOT_FOUND.value())
+                .setBody("User not found"));
+
+        String createUserResponseJson = """
+            {
+              "message": "created",
+              "user": {
+                "username": "test_user"
+              }
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(HttpStatus.OK.value())
+                .setBody(createUserResponseJson)
+                .addHeader("Content-Type", "application/json"));
+
+        AivenServiceUser result = service.ensureUserForService("test_user");
+
+        assertEquals("test_user", result.getUsername());
+        assertEquals(2, mockWebServer.getRequestCount());
+
+        assertEquals("GET", mockWebServer.takeRequest().getMethod());
+        assertEquals("POST", mockWebServer.takeRequest().getMethod());
     }
 }

--- a/src/test/groovy/no/fintlabs/operator/NameFactorySpec.groovy
+++ b/src/test/groovy/no/fintlabs/operator/NameFactorySpec.groovy
@@ -1,20 +1,180 @@
 package no.fintlabs.operator
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class NameFactorySpec extends Specification {
 
-    def "Name should contain orgId and team"() {
-        given:
-        def crd = new KafkaUserAndAclCrd()
-        crd.getMetadata().getLabels().put("fintlabs.no/team", "flais")
-        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "flais.io")
-        crd.getMetadata().setName("fint-data-service")
-
+    def "Name should contain sanitized orgId, team, appName and hash"() {
         when:
-        def name = NameFactory.nameFromMetadata(crd)
+        def name = NameFactory.serviceUserName("flais.io", "flais", "fint-data-service")
 
         then:
-        name == "flais-io_flais_fint-data-service"
+        name ==~ /flais_io_flais_fint-data-service_[a-f0-9]{8}/
+    }
+
+    def "Name should replace dots with underscore"() {
+        when:
+        def name = NameFactory.serviceUserName("flais.io", "flais", "fint.data.service")
+
+        then:
+        name ==~ /flais_io_flais_fint_data_service_[a-f0-9]{8}/
+        !name.contains(".")
+    }
+
+    def "Name should remove team prefix from team name"() {
+        when:
+        def name = NameFactory.serviceUserName("flais.io", "teamflais", "fint-data-service")
+
+        then:
+        name ==~ /flais_io_flais_fint-data-service_[a-f0-9]{8}/
+    }
+
+    def "Name should remove _no suffix from org name"() {
+        when:
+        def name = NameFactory.serviceUserName("flais_no", "flais", "fint-data-service")
+
+        then:
+        name ==~ /flais_flais_fint-data-service_[a-f0-9]{8}/
+    }
+
+    def "Name should remove team name prefix from app name"() {
+        when:
+        def name = NameFactory.serviceUserName("flais.io", "team-flais", "team-flais-service")
+
+        then:
+        name ==~ /flais_io_flais_service_[a-f0-9]{8}/
+    }
+
+    def "Name should shorten long values"() {
+        when:
+        def name = NameFactory.serviceUserName(
+                "very-long-org-name.io",
+                "even-longer-team-name-here",
+                "very-long-application-name-service"
+        )
+
+        then:
+        name ==~ /very-long_even-longer-tea_very-long-application-nam_[a-f0-9]{8}/
+    }
+
+    def "Name should be deterministic"() {
+        when:
+        def name1 = NameFactory.serviceUserName("flais.io", "flais", "fint-data-service")
+        def name2 = NameFactory.serviceUserName("flais.io", "flais", "fint-data-service")
+
+        then:
+        name1 == name2
+    }
+
+    def "Different inpup should produce different hash"() {
+        when:
+        def name1 = NameFactory.serviceUserName("flais.io", "flais", "fint-data-service")
+        def name2 = NameFactory.serviceUserName("flais.io", "flais", "novari-data-service")
+
+        then:
+        name1 != name2
+    }
+
+    @Unroll
+    def "Name should sanitize '#orgName', '#teamName', '#appName'"() {
+        when:
+        def name = NameFactory.serviceUserName(orgName, teamName, appName)
+
+        then:
+        name ==~ expected
+
+        where:
+        orgName     | teamName     | appName             || expected
+        "flais.io"  | "flais"      | "app"               || /flais_io_flais_app_[a-f0-9]{8}/
+        "foo.bar"   | "teamalpha"  | "alpha-api"         || /foo_bar_alpha_alpha-api_[a-f0-9]{8}/
+        "kunde_no"  | "teambeta"   | "beta-service"      || /kunde_beta_beta-service_[a-f0-9]{8}/
+        "-test.io"  | "-teamgamma" | "-gamma-service-"   || /test_io_teamgamma_gamma-service_[a-f0-9]{8}/
+    }
+
+    def "userName should use legacy username when annotation is missing"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "test.io")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test")
+        crd.getMetadata().setName("test-data-service")
+
+        when:
+        def name = NameFactory.userName(crd)
+
+        then:
+        name == "test-io_test_test-data-service"
+
+    }
+
+    def "userName should use legacy username when annotations is null"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().setAnnotations(null)
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "test.io")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test")
+        crd.getMetadata().setName("test-data-service")
+
+        when:
+        def name = NameFactory.userName(crd)
+
+        then:
+        name == "test-io_test_test-data-service"
+    }
+
+    def "userName should use legacy username when annotation is not v2"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "test.io")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test")
+        crd.getMetadata().setName("test-data-service")
+        crd.getMetadata().getAnnotations().put("kafka.fintlabs.no/name-version", "v1")
+
+        when:
+        def name = NameFactory.userName(crd)
+
+        then:
+        name == "test-io_test_test-data-service"
+    }
+
+    def "userName should use v2 username when annotation is v2"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "test.io")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test")
+        crd.getMetadata().setName("test-data-service")
+        crd.getMetadata().getAnnotations().put("kafka.fintlabs.no/name-version", "v2")
+
+        when:
+        def name = NameFactory.userName(crd)
+        then:
+        name ==~ /test_io_test_data-service_[a-f0-9]{8}/
+    }
+
+    def "legacyUserName should replace dots with hyphen"() {
+        given:
+        def crd = new KafkaUserAndAclCrd()
+        crd.getMetadata().getLabels().put("fintlabs.no/org-id", "test.io")
+        crd.getMetadata().getLabels().put("fintlabs.no/team", "test")
+        crd.getMetadata().setName("test-data-service")
+
+        expect:
+        NameFactory.legacyUserName(crd) == "test-io_test_test-data-service"
+    }
+
+    def "userName should not mutate annotations when annotations are null"() {
+        given:
+        def resource = new KafkaUserAndAclCrd()
+        resource.getMetadata().setAnnotations(null)
+        resource.getMetadata().setName("test-data-service")
+        resource.getMetadata().getLabels().put("fintlabs.no/org-id", "test.io")
+        resource.getMetadata().getLabels().put("fintlabs.no/team", "test")
+
+        when:
+        def name = NameFactory.userName(resource)
+
+        then:
+        name == "test-io_test_test-data-service"
+        resource.getMetadata().getAnnotations() == null
     }
 }


### PR DESCRIPTION
Mark: This PR also contains 1648-Create annotation for legacy or new method. This is done since FLA-1647 would probably break the existing users on deployment.

- Cleanup code and added another test
- Refactored and updated to use v2 annotation
- Added more tests
- Added sanitizion
- Implemented serviceUserName in desired and fetch
- Re-wrote to use serviceuser name and legacy user name